### PR TITLE
Re-export log macros

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@ extern crate test;
 extern crate lazy_static;
 pub use lazy_static::lazy_static;
 
+extern crate log;
+pub use log::{debug, error, info, trace, warn};
+
 pub mod block;
 pub mod chunk;
 pub mod events;

--- a/src/utils/logging/mod.rs
+++ b/src/utils/logging/mod.rs
@@ -3,7 +3,7 @@ mod multi_logger;
 mod stdout_logger;
 
 pub use file_logger::{FileLogger, FileLoggerOptions};
-pub use log::{debug, error, info, trace, warn, Level, Log};
+pub use log::{Level, Log};
 pub use stdout_logger::StdoutLogger;
 
 use log::LevelFilter;


### PR DESCRIPTION
This is gonna break the client on the current master but simple fix is to just remove all the imports to log macros